### PR TITLE
Revert "nixos/disnix: fix broken service because of rename"

### DIFF
--- a/nixos/modules/services/misc/disnix.nix
+++ b/nixos/modules/services/misc/disnix.nix
@@ -47,7 +47,7 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    dysnomia.enable = true;
+    services.dysnomia.enable = true;
 
     environment.systemPackages = [ pkgs.disnix ] ++ optional cfg.useWebServiceInterface pkgs.DisnixWebService;
 

--- a/nixos/modules/services/misc/dysnomia.nix
+++ b/nixos/modules/services/misc/dysnomia.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  cfg = config.dysnomia;
+  cfg = config.services.dysnomia;
 
   printProperties = properties:
     concatMapStrings (propertyName:
@@ -69,7 +69,7 @@ let
 in
 {
   options = {
-    dysnomia = {
+    services.dysnomia = {
 
       enable = mkOption {
         type = types.bool;
@@ -142,7 +142,7 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    dysnomia.package = pkgs.dysnomia.override (origArgs: {
+    services.dysnomia.package = pkgs.dysnomia.override (origArgs: {
       enableApacheWebApplication = config.services.httpd.enable;
       enableAxis2WebService = config.services.tomcat.axis2.enable;
       enableEjabberdDump = config.services.ejabberd.enable;
@@ -153,7 +153,7 @@ in
       enableMongoDatabase = config.services.mongodb.enable;
     });
 
-    dysnomia.properties = {
+    services.dysnomia.properties = {
       hostname = config.networking.hostName;
       inherit (config.nixpkgs.localSystem) system;
 
@@ -171,7 +171,7 @@ in
       }}");
     };
 
-    dysnomia.containers = lib.recursiveUpdate ({
+    services.dysnomia.containers = lib.recursiveUpdate ({
       process = {};
       wrapper = {};
     }


### PR DESCRIPTION
Broke evaluation of the nixos options.

  The option `services.dysnomia' defined in `.../nixos/modules/rename.nix' does not exist.

This reverts commit 5c897b4effc4f51b2d6aa5dba158a839b179d964.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

